### PR TITLE
Fix wheel generation path

### DIFF
--- a/cling/python/cppyy_backend/cmake/FindCppyy.cmake
+++ b/cling/python/cppyy_backend/cmake/FindCppyy.cmake
@@ -569,7 +569,7 @@ function(cppyy_add_bindings pkg pkg_version author author_email)
     add_custom_command(OUTPUT  ${pkg_whl}
                        COMMAND ${LibClang_PYTHON_EXECUTABLE} setup.py bdist_wheel
                        DEPENDS ${SETUP_PY_FILE} ${lib_name} ${setup_cfg}
-                       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
     add_custom_target(wheel ALL
                       DEPENDS ${pkg_whl}


### PR DESCRIPTION
Hey,
I encountered that building bindings with cppyy does not work if you are using a hierarchically structured cmake layout. This PR fixes the problem to allow bindings to be build from paths like root/bindings/CMakeLists.txt