### PR TITLE
Reduce memory usage while downloading release

### DIFF
--- a/cling/create_src_directory.py
+++ b/cling/create_src_directory.py
@@ -51,10 +51,9 @@ if not os.path.exists(os.path.join(TARBALL_CACHE_DIR, fn)):
             output_fn = fn
         else:
             output_fn = bytes(fn, 'utf-8')
-        resp = urllib2.urlopen(addr, output_fn)
-        out = open(os.path.join(TARBALL_CACHE_DIR, fn), 'wb')
-        out.write(resp.read())
-        out.close()
+        with urllib2.urlopen(addr, output_fn) as resp:
+            with open(os.path.join(TARBALL_CACHE_DIR, fn), 'wb') as out:
+                shutil.copyfileobj(resp, out)
     except urllib2.HTTPError:
         print('release %s not found' % ROOT_VERSION)
         sys.exit(ERR_RELEASE_NOT_FOUND)


### PR DESCRIPTION
This pull request optimizes the code to download the release tarball with two changes:

1. Use context managers to automatically close the output file and HTTP response object removing the need for an explicit close call and handling the resource cleanup in cases of unexpected crashes, etc.
2. Instead of reading the entire response into memory, download it in chunks and write to the output file as the chunks arrive, curtsy of [shutil.copyfileobj](https://docs.python.org/3/library/shutil.html#shutil.copyfileobj).