### PR TITLE
fix single namespace limitation for pythonization via cmake generator

### DIFF
--- a/cling/python/cppyy_backend/pkg_templates/initializor.py
+++ b/cling/python/cppyy_backend/pkg_templates/initializor.py
@@ -63,7 +63,7 @@ def add_pythonizations(py_files, noisy=False):
                 continue
             tokens = name.split('_')
             if len(tokens) > 1:
-                namespace = tokens[1]
+                namespace = "::".join(tokens[1:])
                 if noisy:
                     print('added pythonization', func, namespace)
                 if namespace == 'gbl':
@@ -218,3 +218,4 @@ def initialise(pkg, lib_file, map_file, noisy=False):
                 continue
             simplenames = child["name"].split('::')
             add_to_pkg(file["name"], child["kind"], simplenames, child)
+


### PR DESCRIPTION
With the current implementation it is not possible to add pythonizations for nested namespaces. The proposed fix joins the remaining tokens with "::" to register the nested namespace.