### PR TITLE
ptr/reftype overload solution in CompareMethodArg

### DIFF
--- a/cling/src/core/meta/inc/TInterpreter.h
+++ b/cling/src/core/meta/inc/TInterpreter.h
@@ -473,10 +473,14 @@ public:
    virtual Bool_t IsIntegerType(const void * /* QualTypePtr */) const {return 0;}
    virtual Bool_t IsSignedIntegerType(const void * /* QualTypePtr */) const {return 0;}
    virtual Bool_t IsUnsignedIntegerType(const void * /* QualTypePtr */) const {return 0;}
+   virtual Bool_t IsIntegralType(const void * /* QualTypePtr */) const {return 0;}
    virtual Bool_t IsFloatingType(const void * /* QualTypePtr */) const {return 0;}
    virtual Bool_t IsPointerType(const void * /* QualTypePtr */) const {return 0;}
    virtual Bool_t IsVoidPointerType(const void * /* QualTypePtr */) const {return 0;}
-
+   virtual TypeInfo_t *GetNonReferenceType(const void * /* QualTypePtr */) const {return 0;}
+   virtual TypeInfo_t *GetUnqualifiedType(const void * /* QualTypePtr */) const {return 0;}
+   virtual TypeInfo_t *GetPointerType(const void * /* QualTypePtr */) const {return 0;}
+   
 // FunctionDecl interface 
    virtual Bool_t FunctionDeclId_IsMethod(DeclId_t /* fdeclid */) const {return 0;}
 };

--- a/cling/src/core/metacling/src/TCling.cxx
+++ b/cling/src/core/metacling/src/TCling.cxx
@@ -8479,6 +8479,15 @@ bool TCling::IsIntegerType(const void * QualTypePtr) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool TCling::IsIntegralType(const void * QualTypePtr) const
+{
+   clang::QualType QT = clang::QualType::getFromOpaquePtr(QualTypePtr);
+   const clang::ASTContext& astContext = fInterpreter->getCI()->getASTContext();
+   return QT->isIntegralType(astContext);
+} 
+
+////////////////////////////////////////////////////////////////////////////////
+
 bool TCling::IsSignedIntegerType(const void * QualTypePtr) const
 {
    clang::QualType QT = clang::QualType::getFromOpaquePtr(QualTypePtr);
@@ -8517,6 +8526,33 @@ bool TCling::IsVoidPointerType(const void * QualTypePtr) const
    return QT->isVoidPointerType();
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+TypeInfo_t* TCling::GetNonReferenceType(const void * QualTypePtr) const
+{
+   clang::QualType QT = clang::QualType::getFromOpaquePtr(QualTypePtr);
+   clang::QualType QT1 = QT.getNonReferenceType();
+   return (TypeInfo_t*) new TClingTypeInfo(GetInterpreterImpl(), QT1);
+
+}
+////////////////////////////////////////////////////////////////////////////////
+
+TypeInfo_t* TCling::GetUnqualifiedType(const void * QualTypePtr) const
+{
+   clang::QualType QT = clang::QualType::getFromOpaquePtr(QualTypePtr);
+   clang::QualType QT1 = QT.getUnqualifiedType();
+   return (TypeInfo_t*) new TClingTypeInfo(GetInterpreterImpl(), QT1);
+
+}
+////////////////////////////////////////////////////////////////////////////////
+
+TypeInfo_t* TCling::GetPointerType(const void * QualTypePtr) const
+{
+   clang::QualType QT = clang::QualType::getFromOpaquePtr(QualTypePtr);
+   clang::QualType QT1 = QT->getPointeeType();
+   return (TypeInfo_t*) new TClingTypeInfo(GetInterpreterImpl(), QT1);
+
+}
 ////////////////////////////////////////////////////////////////////////////////
 
 bool TCling::FunctionDeclId_IsMethod(DeclId_t fdeclid) const

--- a/cling/src/core/metacling/src/TCling.h
+++ b/cling/src/core/metacling/src/TCling.h
@@ -595,12 +595,13 @@ public:
    virtual bool IsFloatingType(const void * QualTypePtr) const;
    virtual bool IsPointerType(const void * QualTypePtr) const;
    virtual bool IsVoidPointerType(const void * QualTypePtr) const;
+
+// FunctionDecl interface 
+   bool FunctionDeclId_IsMethod(DeclId_t fdeclid) const;
+
    virtual TypeInfo_t* GetNonReferenceType(const void * QualTypePtr) const;
    virtual TypeInfo_t* GetUnqualifiedType(const void * QualTypePtr) const;
    virtual TypeInfo_t* GetPointerType(const void * QualTypePtr) const;
-   
-// FunctionDecl interface 
-   bool FunctionDeclId_IsMethod(DeclId_t fdeclid) const;
 };
 
 } // namespace CppyyLegacy

--- a/cling/src/core/metacling/src/TCling.h
+++ b/cling/src/core/metacling/src/TCling.h
@@ -580,7 +580,7 @@ private: // Private Utility Functions and Classes
    virtual ClassInfo_t  *ClassInfo_FactoryWithScope(Bool_t /*all*/ = kTRUE, const char* /*scope*/ = nullptr) const;
 
 public:
-// additional MethodArgInfo interface 
+// additional MethodArgInfo interface
    virtual TypeInfo_t* MethodArgInfo_TypeInfo(MethodArgInfo_t *marginfo) const;
 
 // additional TypeInfo interface

--- a/cling/src/core/metacling/src/TCling.h
+++ b/cling/src/core/metacling/src/TCling.h
@@ -580,7 +580,7 @@ private: // Private Utility Functions and Classes
    virtual ClassInfo_t  *ClassInfo_FactoryWithScope(Bool_t /*all*/ = kTRUE, const char* /*scope*/ = nullptr) const;
 
 public:
-// additional MethodArgInfo interface
+// additional MethodArgInfo interface 
    virtual TypeInfo_t* MethodArgInfo_TypeInfo(MethodArgInfo_t *marginfo) const;
 
 // additional TypeInfo interface
@@ -591,10 +591,14 @@ public:
    virtual bool IsIntegerType(const void * QualTypePtr) const;
    virtual bool IsSignedIntegerType(const void * QualTypePtr) const;
    virtual bool IsUnsignedIntegerType(const void * QualTypePtr) const;
+   virtual bool IsIntegralType(const void * QualTypePtr) const;
    virtual bool IsFloatingType(const void * QualTypePtr) const;
    virtual bool IsPointerType(const void * QualTypePtr) const;
    virtual bool IsVoidPointerType(const void * QualTypePtr) const;
-
+   virtual TypeInfo_t* GetNonReferenceType(const void * QualTypePtr) const;
+   virtual TypeInfo_t* GetUnqualifiedType(const void * QualTypePtr) const;
+   virtual TypeInfo_t* GetPointerType(const void * QualTypePtr) const;
+   
 // FunctionDecl interface 
    bool FunctionDeclId_IsMethod(DeclId_t fdeclid) const;
 };

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1715,7 +1715,6 @@ Cppyy::TCppIndex_t Cppyy::CompareMethodArgType(TCppMethod_t method, TCppIndex_t 
     if (method) {
         TFunction* f = m2f(method);
         TMethodArg* arg = (TMethodArg *)f->GetListOfMethodArgs()->At((int)iarg);
-
         void *argqtp = gInterpreter->TypeInfo_QualTypePtr(arg->GetTypeInfo());
 
         TypeInfo_t *reqti = gInterpreter->TypeInfo_Factory(req_type.c_str());
@@ -1758,10 +1757,8 @@ Cppyy::TCppIndex_t Cppyy::ArgSimilarityScore(void *argqtp, void *reqqtp)
         else if ((gInterpreter->IsIntegerType(argqtp) && gInterpreter->IsIntegerType(reqqtp)))
             return 3;
         else if ((gInterpreter->IsIntegralType(argqtp) && gInterpreter->IsIntegralType(reqqtp)))
-            {
             return 4;
-            }
-        else if ((gInterpreter->IsPointerType(argqtp) && gInterpreter->IsPointerType(reqqtp)))
+        else if ((gInterpreter->IsVoidPointerType(argqtp) && gInterpreter->IsPointerType(reqqtp)))
             return 5;
         else 
             return 10; // Penalize heavily for no possible match

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1721,9 +1721,9 @@ Cppyy::TCppIndex_t Cppyy::CompareMethodArgType(TCppMethod_t method, TCppIndex_t 
         TypeInfo_t *reqti = gInterpreter->TypeInfo_Factory(req_type.c_str());
         void *reqqtp = gInterpreter->TypeInfo_QualTypePtr(reqti);
 
-        if(GetArgScore(argqtp, reqqtp) < 10)
+        if(ArgSimilarityScore(argqtp, reqqtp) < 10)
         {
-            return GetArgScore(argqtp, reqqtp);
+            return ArgSimilarityScore(argqtp, reqqtp);
         }
         else // Match using underlying types
         {   
@@ -1736,14 +1736,14 @@ Cppyy::TCppIndex_t Cppyy::CompareMethodArgType(TCppMethod_t method, TCppIndex_t 
             argqtp = gInterpreter->TypeInfo_QualTypePtr(gInterpreter->GetUnqualifiedType(gInterpreter->TypeInfo_QualTypePtr(arg_ul)));
             reqqtp = gInterpreter->TypeInfo_QualTypePtr(gInterpreter->GetUnqualifiedType(gInterpreter->TypeInfo_QualTypePtr(req_ul)));
             
-            return GetArgScore(argqtp, reqqtp);
+            return ArgSimilarityScore(argqtp, reqqtp);
         }
         
     }
     return INT_MAX; // Method is not valid
 }
 
-Cppyy::TCppIndex_t Cppyy::GetArgScore(void *argqtp, void *reqqtp)
+Cppyy::TCppIndex_t Cppyy::ArgSimilarityScore(void *argqtp, void *reqqtp)
 {
     // This scoring is not based on any particular rules
         if (gInterpreter->IsSameType(argqtp, reqqtp))

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1742,12 +1742,10 @@ Cppyy::TCppIndex_t Cppyy::CompareMethodArgType(TCppMethod_t method, TCppIndex_t 
         TypeInfo_t *reqti = gInterpreter->TypeInfo_Factory(req_type.c_str());
         void *reqqtp = gInterpreter->TypeInfo_QualTypePtr(reqti);
 
-        if(ArgSimilarityScore(argqtp, reqqtp) < 10)
-        {
+        if (ArgSimilarityScore(argqtp, reqqtp) < 10) {
             return ArgSimilarityScore(argqtp, reqqtp);
         }
-        else // Match using underlying types
-        {   
+        else { // Match using underlying types   
             if(gInterpreter->IsPointerType(argqtp))
                 argqtp = gInterpreter->TypeInfo_QualTypePtr(gInterpreter->GetPointerType(argqtp));
 
@@ -1758,8 +1756,7 @@ Cppyy::TCppIndex_t Cppyy::CompareMethodArgType(TCppMethod_t method, TCppIndex_t 
             reqqtp = gInterpreter->TypeInfo_QualTypePtr(gInterpreter->GetUnqualifiedType(gInterpreter->TypeInfo_QualTypePtr(req_ul)));
             
             return ArgSimilarityScore(argqtp, reqqtp);
-        }
-        
+        }    
     }
     return INT_MAX; // Method is not valid
 }

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -586,6 +586,28 @@ std::string Cppyy::ResolveEnum(const std::string& enum_type)
     return restype;     // should default to some int variant
 }
 
+static Cppyy::TCppIndex_t ArgSimilarityScore(void *argqtp, void *reqqtp)
+{
+    // This scoring is not based on any particular rules
+        if (gInterpreter->IsSameType(argqtp, reqqtp))
+            return 0; // Best match
+        else if ((gInterpreter->IsSignedIntegerType(argqtp) && gInterpreter->IsSignedIntegerType(reqqtp)) || 
+                 (gInterpreter->IsUnsignedIntegerType(argqtp) && gInterpreter->IsUnsignedIntegerType(reqqtp)) ||
+                 (gInterpreter->IsFloatingType(argqtp) && gInterpreter->IsFloatingType(reqqtp)))
+            return 1;
+        else if ((gInterpreter->IsSignedIntegerType(argqtp) && gInterpreter->IsUnsignedIntegerType(reqqtp)) ||
+                 (gInterpreter->IsFloatingType(argqtp) && gInterpreter->IsUnsignedIntegerType(reqqtp)))
+            return 2;
+        else if ((gInterpreter->IsIntegerType(argqtp) && gInterpreter->IsIntegerType(reqqtp)))
+            return 3;
+        else if ((gInterpreter->IsIntegralType(argqtp) && gInterpreter->IsIntegralType(reqqtp)))
+            return 4;
+        else if ((gInterpreter->IsVoidPointerType(argqtp) && gInterpreter->IsPointerType(reqqtp)))
+            return 5;
+        else 
+            return 10; // Penalize heavily for no possible match
+}
+
 Cppyy::TCppScope_t Cppyy::GetScope(const std::string& sname)
 {
 // First, try cache
@@ -1740,28 +1762,6 @@ Cppyy::TCppIndex_t Cppyy::CompareMethodArgType(TCppMethod_t method, TCppIndex_t 
         
     }
     return INT_MAX; // Method is not valid
-}
-
-Cppyy::TCppIndex_t Cppyy::ArgSimilarityScore(void *argqtp, void *reqqtp)
-{
-    // This scoring is not based on any particular rules
-        if (gInterpreter->IsSameType(argqtp, reqqtp))
-            return 0; // Best match
-        else if ((gInterpreter->IsSignedIntegerType(argqtp) && gInterpreter->IsSignedIntegerType(reqqtp)) || 
-                 (gInterpreter->IsUnsignedIntegerType(argqtp) && gInterpreter->IsUnsignedIntegerType(reqqtp)) ||
-                 (gInterpreter->IsFloatingType(argqtp) && gInterpreter->IsFloatingType(reqqtp)))
-            return 1;
-        else if ((gInterpreter->IsSignedIntegerType(argqtp) && gInterpreter->IsUnsignedIntegerType(reqqtp)) ||
-                 (gInterpreter->IsFloatingType(argqtp) && gInterpreter->IsUnsignedIntegerType(reqqtp)))
-            return 2;
-        else if ((gInterpreter->IsIntegerType(argqtp) && gInterpreter->IsIntegerType(reqqtp)))
-            return 3;
-        else if ((gInterpreter->IsIntegralType(argqtp) && gInterpreter->IsIntegralType(reqqtp)))
-            return 4;
-        else if ((gInterpreter->IsVoidPointerType(argqtp) && gInterpreter->IsPointerType(reqqtp)))
-            return 5;
-        else 
-            return 10; // Penalize heavily for no possible match
 }
 
 std::string Cppyy::GetMethodArgDefault(TCppMethod_t method, TCppIndex_t iarg)

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -203,8 +203,6 @@ namespace Cppyy {
     RPY_EXPORTED
     TCppIndex_t CompareMethodArgType(TCppMethod_t, TCppIndex_t iarg, const std::string &req_type);
     RPY_EXPORTED
-    TCppIndex_t ArgSimilarityScore(void *argqtp, void *reqqtp);
-    RPY_EXPORTED
     std::string GetMethodArgDefault(TCppMethod_t, TCppIndex_t iarg);
     RPY_EXPORTED
     std::string GetMethodSignature(TCppMethod_t, bool show_formalargs, TCppIndex_t maxargs = (TCppIndex_t)-1);

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -203,7 +203,7 @@ namespace Cppyy {
     RPY_EXPORTED
     TCppIndex_t CompareMethodArgType(TCppMethod_t, TCppIndex_t iarg, const std::string &req_type);
     RPY_EXPORTED
-    TCppIndex_t GetArgScore(void *argqtp, void *reqqtp);
+    TCppIndex_t ArgSimilarityScore(void *argqtp, void *reqqtp);
     RPY_EXPORTED
     std::string GetMethodArgDefault(TCppMethod_t, TCppIndex_t iarg);
     RPY_EXPORTED

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -203,6 +203,8 @@ namespace Cppyy {
     RPY_EXPORTED
     TCppIndex_t CompareMethodArgType(TCppMethod_t, TCppIndex_t iarg, const std::string &req_type);
     RPY_EXPORTED
+    TCppIndex_t GetArgScore(void *argqtp, void *reqqtp);
+    RPY_EXPORTED
     std::string GetMethodArgDefault(TCppMethod_t, TCppIndex_t iarg);
     RPY_EXPORTED
     std::string GetMethodSignature(TCppMethod_t, bool show_formalargs, TCppIndex_t maxargs = (TCppIndex_t)-1);


### PR DESCRIPTION
Added ptr/reftype solution via clingwrapper and TCling, exposed clang::Type functions to OpaquePtr Interface to return TypeInfo for - GetNonReferenceType, GetPointerType, GetUnqualifiedType 

Fixed previous long long match failure with clang::QualType GetIntegralType()