### PR TITLE
Improve priority assignment of classes in same inheritance tree

### DIFF
--- a/clingwrapper/src/capi.h
+++ b/clingwrapper/src/capi.h
@@ -138,6 +138,8 @@ extern "C" {
     RPY_EXPORTED
     int cppyy_num_bases(cppyy_type_t type);
     RPY_EXPORTED
+    int cppyy_num_bases_longest_branch(cppyy_type_t type);
+    RPY_EXPORTED
     char* cppyy_base_name(cppyy_type_t type, int base_index);
     RPY_EXPORTED
     int cppyy_is_subtype(cppyy_type_t derived, cppyy_type_t base);

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -1459,6 +1459,83 @@ Cppyy::TCppIndex_t Cppyy::GetNumBases(TCppType_t klass)
     return (TCppIndex_t)0;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// \fn Cppyy::TCppIndex_t GetLongestInheritancePath(TClass *klass)
+/// \brief Retrieve number of base classes in the longest branch of the
+///        inheritance tree of the input class.
+/// \param[in] klass The class to start the retrieval process from.
+///
+/// This is a helper function for Cppyy::GetNumBasesLongestBranch.
+/// Given an inheritance tree, the function assigns weight 1 to each class that
+/// has at least one base. Starting from the input class, the function is
+/// called recursively on all the bases. For each base the return value is one
+/// (the weight of the base itself) plus the maximum value retrieved for their
+/// bases in turn. For example, given the following inheritance tree:
+///
+/// ~~~{.cpp}
+/// class A {}; class B: public A {};
+/// class X {}; class Y: public X {}; class Z: public Y {};
+/// class C: public B, Z {};
+/// ~~~
+///
+/// calling this function on an instance of `C` will return 3, the steps
+/// required to go from C to X.
+Cppyy::TCppIndex_t GetLongestInheritancePath(TClass *klass)
+{
+
+   auto directbases = klass->GetListOfBases();
+   if (!directbases) {
+      // This is a leaf with no bases
+      return 0;
+   }
+   auto ndirectbases = directbases->GetSize();
+   if (ndirectbases == 0) {
+      // This is a leaf with no bases
+      return 0;
+   } else {
+      // If there is at least one direct base
+      std::vector<Cppyy::TCppIndex_t> nbases_branches;
+      nbases_branches.reserve(ndirectbases);
+
+      // Traverse all direct bases of the current class and call the function
+      // recursively
+      for (auto baseclass : TRangeDynCast<TBaseClass>(directbases)) {
+         if (!baseclass)
+            continue;
+         if (auto baseclass_tclass = baseclass->GetClassPointer()) {
+            nbases_branches.emplace_back(GetLongestInheritancePath(baseclass_tclass));
+         }
+      }
+
+      // Get longest path among the direct bases of the current class
+      auto longestbranch = std::max_element(std::begin(nbases_branches), std::end(nbases_branches));
+
+      // Add 1 to include the current class in the count
+      return 1 + *longestbranch;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \fn Cppyy::TCppIndex_t Cppyy::GetNumBasesLongest(TCppType_t klass)
+/// \brief Retrieve number of base classes in the longest branch of the
+///        inheritance tree.
+/// \param[in] klass The class to start the retrieval process from.
+///
+/// The function converts the input class to a `TClass *` and calls
+/// GetLongestInheritancePath.
+Cppyy::TCppIndex_t Cppyy::GetNumBasesLongestBranch(TCppType_t klass)
+{
+
+   const auto &cr = type_from_handle(klass);
+
+   if (auto klass_tclass = cr.GetClass()) {
+      return GetLongestInheritancePath(klass_tclass);
+   }
+
+   // In any other case, return zero
+   return 0;
+}
+
 std::string Cppyy::GetBaseName(TCppType_t klass, TCppIndex_t ibase)
 {
     TClassRef& cr = type_from_handle(klass);

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -157,6 +157,8 @@ namespace Cppyy {
     RPY_EXPORTED
     TCppIndex_t GetNumBases(TCppType_t type);
     RPY_EXPORTED
+    TCppIndex_t GetNumBasesLongestBranch(TCppType_t type);
+    RPY_EXPORTED
     std::string GetBaseName(TCppType_t type, TCppIndex_t ibase);
     RPY_EXPORTED
     bool        IsSubtype(TCppType_t derived, TCppType_t base);


### PR DESCRIPTION
 - **Port of https://github.com/root-project/root/pull/9092**
 - **Corresponding CPyCppyy PR: https://github.com/wlav/CPyCppyy/pull/17**

---------------------

The current implementation of the CPPMethod::GetPriority function considers only direct bases of the class type given as input parameter to a certain function. This can lead to situations which are easily distinguishable but that lead to the same overload being called when passing instances of different classes of the same inheritance tree.

For example,
```python
import ROOT

ROOT.gInterpreter.Declare(
'''
class A {};
class B: public A {};
class C: public B {};

void myfunc(const B &b){
    std::cout << "B" << std::endl;
}

void myfunc(const C &c){
    std::cout << "C" << std::endl;
}

''')

ROOT.myfunc(ROOT.B())
ROOT.myfunc(ROOT.C())
```

Prints `B` for both function calls. This commit introduces a new function in cppyy that retrieves the number of bases in the longest branch of the inheritance tree for a certain class. This helps better distinguish cases like the one above, that are now solved.

The new logic still does not solve another issue, namely the fact that in certain situations which would throw errors in C++ due to their ambiguity, cppyy resorts to calling the function overload with the highest priority. A couple of tests have been added in roottest to show both behaviours.