### PR TITLE
Add rstring to _cppyy_generator.py for python 3.12.2

### DIFF
--- a/cling/python/cppyy_backend/_cppyy_generator.py
+++ b/cling/python/cppyy_backend/_cppyy_generator.py
@@ -664,7 +664,7 @@ def getBuiltinHeaderPath(library_path):
 
 
 def main(argv=None):
-    """
+    r"""
     Takes a set of C++ header files and generate a JSON output file describing
     the objects found in them. This output is intended to support more
     convenient access to a set of cppyy-supported bindings.


### PR DESCRIPTION
Fix cmake warning for python 3.12