### PR TITLE
Allow skipping rebuild of PCH

### DIFF
--- a/cling/python/cppyy_backend/loader.py
+++ b/cling/python/cppyy_backend/loader.py
@@ -145,6 +145,8 @@ def _is_uptodate(pchname, incpath):
     force_rebuild = os.environ.get('CLING_REBUILD_PCH', '')
     if force_rebuild == '1' or force_rebuild.lower() == 'true':
        return False
+    elif force_rebuild == '0' or force_rebuild.lower() == 'false':
+       return True
 
   # it's unlikely there's a C++ compiler available when distributed as a
   # frozen bundle, so accept the PCH if any exists


### PR DESCRIPTION
Motivation: Currently, if the include dir in conda env is newer than PCH, we will always rebuild. In fact, it's useful to be able to skip the rebuild if you have a valid PCH you'd like to use, regardless of the age of the conda env.