### PR TITLE
Return scope type in `GetActualClass` only if TClass has ClassInfo

### DIFF
--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -741,7 +741,8 @@ Cppyy::TCppType_t Cppyy::GetActualClass(TCppType_t klass, TCppObject_t obj)
 #endif
 
     TClass* clActual = cr->GetActualClass((void*)obj);
-    if (clActual && clActual != cr.GetClass()) {
+    // The additional check using TClass::GetClassInfo is to prevent returning classes of which the Interpreter has no info (see https://github.com/root-project/root/pull/16177)
+    if (clActual && clActual != cr.GetClass() && clActual->GetClassInfo()) {
         auto itt = g_name2classrefidx.find(clActual->GetName());
         if (itt != g_name2classrefidx.end())
             return (TCppType_t)itt->second;


### PR DESCRIPTION
See https://github.com/root-project/root/pull/16177 