### PR TITLE
Remove attempt to POST request download of cling ROOT tarball

### DIFF
--- a/cling/create_src_directory.py
+++ b/cling/create_src_directory.py
@@ -52,11 +52,7 @@ addr = 'https://root.cern.ch/download/'+fn
 if not os.path.exists(os.path.join(TARBALL_CACHE_DIR, fn)):
     try:
         print('retrieving', fn)
-        if sys.hexversion < 0x3000000:
-            output_fn = fn
-        else:
-            output_fn = bytes(fn, 'utf-8')
-        with contextlib.closing(urllib2.urlopen(addr, output_fn)) as resp:
+        with contextlib.closing(urllib2.urlopen(addr)) as resp:
             with open(os.path.join(TARBALL_CACHE_DIR, fn), 'wb') as out:
                 shutil.copyfileobj(resp, out)
     except urllib2.HTTPError:


### PR DESCRIPTION
Not sure what the original intent here was, but the docs for both python 2 (https://docs.python.org/2/library/urllib2.html#urllib2.urlopen) and urllib.request for python 3 (https://docs.python.org/3.8/library/urllib.request.html#urllib.request.urlopen) both show the second parameter here as being for the data that is used in a POST request or similar.

The ROOT server isn't configured to allow POST requests to download the file, and so responds with a 405.

$ curl -I -X GET https://root.cern.ch/download/root_v6.32.08.source.tar.gz
HTTP/1.1 200 OK
...

$ curl -I -X POST https://root.cern.ch/download/root_v6.32.08.source.tar.gz
HTTP/1.1 405 Method Not Allowed
...
