### PR TITLE
Add `Cppyy::IsExplicit` check to check for explicit constructors

### DIFF
--- a/clingwrapper/src/capi.h
+++ b/clingwrapper/src/capi.h
@@ -227,6 +227,8 @@ extern "C" {
     int cppyy_is_destructor(cppyy_method_t);
     RPY_EXPORTED
     int cppyy_is_staticmethod(cppyy_method_t);
+    RPY_EXPORTED
+    int cppyy_is_explicit(cppyy_method_t);
 
     /* data member reflection information ------------------------------------- */
     RPY_EXPORTED

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -2198,49 +2198,51 @@ Cppyy::TCppIndex_t Cppyy::GetGlobalOperator(
 }
 
 // method properties ---------------------------------------------------------
+
+static inline bool testMethodProperty(Cppyy::TCppMethod_t method, EProperty prop)
+{
+    if (!method)
+        return false;
+    TFunction *f = m2f(method);
+    return f->Property() & prop;
+}
+
+static inline bool testMethodExtraProperty(Cppyy::TCppMethod_t method, EFunctionProperty prop)
+{
+    if (!method)
+        return false;
+    TFunction *f = m2f(method);
+    return f->ExtraProperty() & prop;
+}
+
 bool Cppyy::IsPublicMethod(TCppMethod_t method)
 {
-    if (method) {
-        TFunction* f = m2f(method);
-        return f->Property() & kIsPublic;
-    }
-    return false;
+    return testMethodProperty(method, kIsPublic);
 }
 
 bool Cppyy::IsProtectedMethod(TCppMethod_t method)
 {
-    if (method) {
-        TFunction* f = m2f(method);
-        return f->Property() & kIsProtected;
-    }
-    return false;
+    return testMethodProperty(method, kIsProtected);
 }
 
 bool Cppyy::IsConstructor(TCppMethod_t method)
 {
-    if (method) {
-        TFunction* f = m2f(method);
-        return f->ExtraProperty() & kIsConstructor;
-    }
-    return false;
+    return testMethodExtraProperty(method, kIsConstructor);
 }
 
 bool Cppyy::IsDestructor(TCppMethod_t method)
 {
-    if (method) {
-        TFunction* f = m2f(method);
-        return f->ExtraProperty() & kIsDestructor;
-    }
-    return false;
+    return testMethodExtraProperty(method, kIsDestructor);
 }
 
 bool Cppyy::IsStaticMethod(TCppMethod_t method)
 {
-    if (method) {
-        TFunction* f = m2f(method);
-        return f->Property() & kIsStatic;
-    }
-    return false;
+    return testMethodProperty(method, kIsStatic);
+}
+
+bool Cppyy::IsExplicit(TCppMethod_t method)
+{
+    return testMethodProperty(method, kIsExplicit);
 }
 
 // data member reflection information ----------------------------------------
@@ -3059,6 +3061,10 @@ int cppyy_is_destructor(cppyy_method_t method) {
 
 int cppyy_is_staticmethod(cppyy_method_t method) {
     return (int)Cppyy::IsStaticMethod((Cppyy::TCppMethod_t)method);
+}
+
+int cppyy_is_explicit(cppyy_method_t method) {
+    return (int)Cppyy::IsExplicit((Cppyy::TCppMethod_t)method);
 }
 
 

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -244,6 +244,8 @@ namespace Cppyy {
     bool IsDestructor(TCppMethod_t method);
     RPY_EXPORTED
     bool IsStaticMethod(TCppMethod_t method);
+    RPY_EXPORTED
+    bool IsExplicit(TCppMethod_t method);
 
 // data member reflection information ----------------------------------------
     RPY_EXPORTED


### PR DESCRIPTION
This is important to avoid implicit conversions over explicit constructors.

Taken from https://github.com/root-project/root/pull/19513.