### PR TITLE
Add bitfield support to cling backend and clingwrapper C API

### DIFF
--- a/cling/src/core/meta/inc/TDataMember.h
+++ b/cling/src/core/meta/inc/TDataMember.h
@@ -79,6 +79,9 @@ public:
    TList         *GetOptions() const;
 
    Bool_t         IsBasic() const;
+   Bool_t         IsBitField() const;
+   Int_t          GetBitFieldOffset() const;
+   Int_t          GetBitFieldSize() const;
    Bool_t         IsEnum() const;
    Bool_t         IsaPointer() const;
    Bool_t         IsPersistent() const { return TestBit(kObjIsPersistent); }

--- a/cling/src/core/meta/inc/TInterpreter.h
+++ b/cling/src/core/meta/inc/TInterpreter.h
@@ -370,6 +370,9 @@ public:
    virtual int    DataMemberInfo_MaxIndex(DataMemberInfo_t * /* dminfo */, Int_t  /* dim */) const {return 0;}
    virtual int    DataMemberInfo_Next(DataMemberInfo_t * /* dminfo */) const {return 0;}
    virtual intptr_t DataMemberInfo_Offset(DataMemberInfo_t * /* dminfo */) const {return 0;}
+   virtual Bool_t DataMemberInfo_IsBitField(DataMemberInfo_t * /* dminfo */) const {return false;}
+   virtual int    DataMemberInfo_BitFieldOffset(DataMemberInfo_t * /* dminfo */) const {return -1;}
+   virtual int    DataMemberInfo_BitFieldSize(DataMemberInfo_t * /* dminfo */) const {return -1;}
    virtual Long_t DataMemberInfo_Property(DataMemberInfo_t * /* dminfo */) const {return 0;}
    virtual Long_t DataMemberInfo_TypeProperty(DataMemberInfo_t * /* dminfo */) const {return 0;}
    virtual int    DataMemberInfo_TypeSize(DataMemberInfo_t * /* dminfo */) const {return 0;}

--- a/cling/src/core/meta/src/TDataMember.cxx
+++ b/cling/src/core/meta/src/TDataMember.cxx
@@ -577,6 +577,38 @@ Bool_t TDataMember::IsBasic() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return true if data member is a bitfield.
+
+Bool_t TDataMember::IsBitField() const
+{
+   if (fInfo)
+      return gCling->DataMemberInfo_IsBitField(fInfo);
+   return kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get bit offset within the immediate parent record (in bits).
+/// Returns -1 if not a bitfield.
+
+Int_t TDataMember::GetBitFieldOffset() const
+{
+   if (fInfo)
+      return gCling->DataMemberInfo_BitFieldOffset(fInfo);
+   return -1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get bit width of the bitfield.
+/// Returns -1 if not a bitfield.
+
+Int_t TDataMember::GetBitFieldSize() const
+{
+   if (fInfo)
+      return gCling->DataMemberInfo_BitFieldSize(fInfo);
+   return -1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return true if data member is an enum.
 
 Bool_t TDataMember::IsEnum() const

--- a/cling/src/core/metacling/src/TCling.cxx
+++ b/cling/src/core/metacling/src/TCling.cxx
@@ -7624,6 +7624,30 @@ intptr_t TCling::DataMemberInfo_Offset(DataMemberInfo_t* dminfo) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
+Bool_t TCling::DataMemberInfo_IsBitField(DataMemberInfo_t* dminfo) const
+{
+   TClingDataMemberInfo* TClinginfo = (TClingDataMemberInfo*) dminfo;
+   return TClinginfo->IsBitField();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+int TCling::DataMemberInfo_BitFieldOffset(DataMemberInfo_t* dminfo) const
+{
+   TClingDataMemberInfo* TClinginfo = (TClingDataMemberInfo*) dminfo;
+   return TClinginfo->BitFieldOffset();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+int TCling::DataMemberInfo_BitFieldSize(DataMemberInfo_t* dminfo) const
+{
+   TClingDataMemberInfo* TClinginfo = (TClingDataMemberInfo*) dminfo;
+   return TClinginfo->BitFieldSize();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 Long_t TCling::DataMemberInfo_Property(DataMemberInfo_t* dminfo) const
 {
    TClingDataMemberInfo* TClinginfo = (TClingDataMemberInfo*) dminfo;

--- a/cling/src/core/metacling/src/TCling.h
+++ b/cling/src/core/metacling/src/TCling.h
@@ -419,6 +419,9 @@ public: // Public Interface
    virtual int    DataMemberInfo_MaxIndex(DataMemberInfo_t* dminfo, Int_t dim) const;
    virtual int    DataMemberInfo_Next(DataMemberInfo_t* dminfo) const;
    virtual intptr_t DataMemberInfo_Offset(DataMemberInfo_t* dminfo) const;
+   virtual Bool_t DataMemberInfo_IsBitField(DataMemberInfo_t* dminfo) const;
+   virtual int    DataMemberInfo_BitFieldOffset(DataMemberInfo_t* dminfo) const;
+   virtual int    DataMemberInfo_BitFieldSize(DataMemberInfo_t* dminfo) const;
    virtual Long_t DataMemberInfo_Property(DataMemberInfo_t* dminfo) const;
    virtual Long_t DataMemberInfo_TypeProperty(DataMemberInfo_t* dminfo) const;
    virtual int    DataMemberInfo_TypeSize(DataMemberInfo_t* dminfo) const;

--- a/cling/src/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/cling/src/core/metacling/src/TClingDataMemberInfo.cxx
@@ -474,6 +474,58 @@ intptr_t TClingDataMemberInfo::Offset()
    return (intptr_t)-1;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+bool TClingDataMemberInfo::IsBitField() const
+{
+   using namespace clang;
+   if (!IsValid())
+      return false;
+   const ValueDecl *VD = GetTargetValueDecl();
+   if (const FieldDecl *FldD = dyn_cast_or_null<FieldDecl>(VD))
+      return FldD->isBitField();
+   return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+int TClingDataMemberInfo::BitFieldOffset()
+{
+   using namespace clang;
+   if (!IsValid())
+      return -1;
+   const ValueDecl *VD = GetTargetValueDecl();
+   if (const FieldDecl *FldD = dyn_cast_or_null<FieldDecl>(VD)) {
+      if (!FldD->isBitField())
+         return -1;
+      cling::Interpreter::PushTransactionRAII RAII(fInterp);
+      ASTContext &C = FldD->getASTContext();
+      const RecordDecl *RD = FldD->getParent();
+      const ASTRecordLayout &Layout = C.getASTRecordLayout(RD);
+      return (int)Layout.getFieldOffset(FldD->getFieldIndex());
+   }
+   return -1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+int TClingDataMemberInfo::BitFieldSize() const
+{
+   using namespace clang;
+   if (!IsValid())
+      return -1;
+   const ValueDecl *VD = GetTargetValueDecl();
+   if (const FieldDecl *FldD = dyn_cast_or_null<FieldDecl>(VD)) {
+      if (!FldD->isBitField())
+         return -1;
+      ASTContext &C = FldD->getASTContext();
+      return (int)FldD->getBitWidthValue(C);
+   }
+   return -1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 long TClingDataMemberInfo::Property() const
 {
    if (!IsValid()) {

--- a/cling/src/core/metacling/src/TClingDataMemberInfo.h
+++ b/cling/src/core/metacling/src/TClingDataMemberInfo.h
@@ -133,6 +133,9 @@ public:
    int                InternalNext();
    bool               Next() { return InternalNext(); }
    intptr_t           Offset();
+   bool               IsBitField() const;
+   int                BitFieldOffset();
+   int                BitFieldSize() const;
    long               Property() const;
    long               TypeProperty() const;
    int                TypeSize() const;

--- a/clingwrapper/src/capi.h
+++ b/clingwrapper/src/capi.h
@@ -258,6 +258,12 @@ extern "C" {
     RPY_EXPORTED
     int cppyy_is_enum_data(cppyy_scope_t scope, cppyy_index_t idata);
     RPY_EXPORTED
+    int cppyy_is_bitfield_data(cppyy_scope_t scope, cppyy_index_t idata);
+    RPY_EXPORTED
+    int cppyy_datamember_bitfield_offset(cppyy_scope_t scope, cppyy_index_t idata);
+    RPY_EXPORTED
+    int cppyy_datamember_bitfield_size(cppyy_scope_t scope, cppyy_index_t idata);
+    RPY_EXPORTED
     int cppyy_get_dimension_size(cppyy_scope_t scope, cppyy_index_t idata, int dimension);
 
     /* enum properties -------------------------------------------------------- */

--- a/clingwrapper/src/clingwrapper.cxx
+++ b/clingwrapper/src/clingwrapper.cxx
@@ -2556,6 +2556,42 @@ bool Cppyy::IsEnumData(TCppScope_t scope, TCppIndex_t idata)
     return false;
 }
 
+bool Cppyy::IsDatamemberBitField(TCppScope_t scope, TCppIndex_t idata)
+{
+    if (scope == GLOBAL_HANDLE)
+        return false;
+    TClassRef& cr = type_from_handle(scope);
+    if (cr.GetClass()) {
+        TDataMember* m = (TDataMember*)cr->GetListOfDataMembers()->At((int)idata);
+        return m->IsBitField();
+    }
+    return false;
+}
+
+int Cppyy::GetDatamemberBitFieldOffset(TCppScope_t scope, TCppIndex_t idata)
+{
+    if (scope == GLOBAL_HANDLE)
+        return -1;
+    TClassRef& cr = type_from_handle(scope);
+    if (cr.GetClass()) {
+        TDataMember* m = (TDataMember*)cr->GetListOfDataMembers()->At((int)idata);
+        return m->GetBitFieldOffset();
+    }
+    return -1;
+}
+
+int Cppyy::GetDatamemberBitFieldSize(TCppScope_t scope, TCppIndex_t idata)
+{
+    if (scope == GLOBAL_HANDLE)
+        return -1;
+    TClassRef& cr = type_from_handle(scope);
+    if (cr.GetClass()) {
+        TDataMember* m = (TDataMember*)cr->GetListOfDataMembers()->At((int)idata);
+        return m->GetBitFieldSize();
+    }
+    return -1;
+}
+
 int Cppyy::GetDimensionSize(TCppScope_t scope, TCppIndex_t idata, int dimension)
 {
     if (scope == GLOBAL_HANDLE) {
@@ -3116,6 +3152,18 @@ int cppyy_is_const_data(cppyy_scope_t scope, cppyy_index_t idata) {
 
 int cppyy_is_enum_data(cppyy_scope_t scope, cppyy_index_t idata) {
     return (int)Cppyy::IsEnumData(scope, idata);
+}
+
+int cppyy_is_bitfield_data(cppyy_scope_t scope, cppyy_index_t idata) {
+    return (int)Cppyy::IsDatamemberBitField(scope, idata);
+}
+
+int cppyy_datamember_bitfield_offset(cppyy_scope_t scope, cppyy_index_t idata) {
+    return Cppyy::GetDatamemberBitFieldOffset(scope, idata);
+}
+
+int cppyy_datamember_bitfield_size(cppyy_scope_t scope, cppyy_index_t idata) {
+    return Cppyy::GetDatamemberBitFieldSize(scope, idata);
 }
 
 int cppyy_get_dimension_size(cppyy_scope_t scope, cppyy_index_t idata, int dimension) {

--- a/clingwrapper/src/cpp_cppyy.h
+++ b/clingwrapper/src/cpp_cppyy.h
@@ -273,6 +273,12 @@ namespace Cppyy {
     RPY_EXPORTED
     bool IsEnumData(TCppScope_t scope, TCppIndex_t idata);
     RPY_EXPORTED
+    bool IsDatamemberBitField(TCppScope_t scope, TCppIndex_t idata);
+    RPY_EXPORTED
+    int  GetDatamemberBitFieldOffset(TCppScope_t scope, TCppIndex_t idata);
+    RPY_EXPORTED
+    int  GetDatamemberBitFieldSize(TCppScope_t scope, TCppIndex_t idata);
+    RPY_EXPORTED
     int  GetDimensionSize(TCppScope_t scope, TCppIndex_t idata, int dimension);
 
 // enum properties -----------------------------------------------------------


### PR DESCRIPTION
Expose bitfield metadata (isBitField, bit offset, bit width) from clang's AST through the full TInterpreter/TCling/TDataMember stack and the clingwrapper Cppyy:: / cppyy_* C API layers.

This enables downstream CPyCppyy to correctly read and write C++ bitfield data members instead of returning the raw storage unit.

Fixes wlav/cppyy#57